### PR TITLE
Add configuration for client notifications

### DIFF
--- a/core/lib/spree/permitted_messages.rb
+++ b/core/lib/spree/permitted_messages.rb
@@ -4,7 +4,11 @@ module Spree
   # need additional params to be accepted can mutate these arrays to add them.
   module PermittedMessages
     MESSAGES = {
-      order_canceled: [['Spree:OrderMailer','cancel_email']]
+      order_canceled: [['Spree::OrderMailer','cancel_email']],
+      order_confirmed: [['Spree::OrderMailer', 'confirm_email']],
+      order_inventory_canceled: [['Spree::OrderMailer', 'inventory_cancellation_email']],
+      carton_shipped: [['Spree::Config.carton_shipped_email_class', 'shipped_email']],
+      reimbursement_processed: [['Spree::ReimbursementMailer', 'reimbursement_mailer']]
     }
 
     mattr_reader(MESSAGES)


### PR DESCRIPTION
The configurable carton class is weird here. But if people are going to
need to configure this anyway it may be fine (they are going to need to
check out this file, and would add it then anyway).