### PR TITLE
Add message dispatching

### DIFF
--- a/backend/app/controllers/spree/admin/orders_controller.rb
+++ b/backend/app/controllers/spree/admin/orders_controller.rb
@@ -138,7 +138,7 @@ module Spree
       end
 
       def resend
-        OrderMailer.confirm_email(@order, true).deliver_later
+        Spree::Dispatcher.send_message(:order_confirm, @order, true)
         flash[:success] = t('spree.order_email_resent')
 
         redirect_to(spree.edit_admin_order_path(@order))

--- a/core/app/models/spree/order.rb
+++ b/core/app/models/spree/order.rb
@@ -433,7 +433,7 @@ module Spree
     end
 
     def deliver_order_confirmation_email
-      Spree::OrderMailer.confirm_email(self).deliver_later
+      Spree::Dispatcher.send_message(:order_confirm, self)
       update_column(:confirmation_delivered, true)
     end
 
@@ -858,7 +858,7 @@ module Spree
     end
 
     def send_cancel_email
-      Spree::OrderMailer.cancel_email(self).deliver_later
+      Spree::Dispatcher.send_message(:order_cancel, self)
     end
 
     def after_resume

--- a/core/app/models/spree/order_cancellations.rb
+++ b/core/app/models/spree/order_cancellations.rb
@@ -38,7 +38,7 @@ class Spree::OrderCancellations
         end
 
         update_shipped_shipments(inventory_units)
-        Spree::OrderMailer.inventory_cancellation_email(@order, inventory_units.to_a).deliver_later if Spree::OrderCancellations.send_cancellation_mailer
+        Spree::Dispatcher.send_message(:order_inventory_cancel, @order, inventory_units.to_a) if Spree::OrderCancellations.send_cancellation_mailer
       end
 
       @order.recalculate

--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -81,7 +81,7 @@ class Spree::OrderShipping
 
   def send_shipment_emails(carton)
     carton.orders.each do |order|
-      Spree::Dispatcher.send_message(:carton_shipped, order, carton)
+      Spree::Dispatcher.send_message(:carton_shipped, order: order, carton: carton)
     end
   end
 end

--- a/core/app/models/spree/order_shipping.rb
+++ b/core/app/models/spree/order_shipping.rb
@@ -81,7 +81,7 @@ class Spree::OrderShipping
 
   def send_shipment_emails(carton)
     carton.orders.each do |order|
-      Spree::Config.carton_shipped_email_class.shipped_email(order: order, carton: carton).deliver_later
+      Spree::Dispatcher.send_message(:carton_shipped, order, carton)
     end
   end
 end

--- a/core/app/models/spree/reimbursement.rb
+++ b/core/app/models/spree/reimbursement.rb
@@ -160,7 +160,7 @@ module Spree
     end
 
     def send_reimbursement_email
-      Spree::ReimbursementMailer.reimbursement_email(id).deliver_later
+      Spree::Dispatcher.send_message(:reimbursement_processed, id)
     end
 
     # If there are multiple different reimbursement types for a single

--- a/core/app/notifications/spree/dispatcher.rb
+++ b/core/app/notifications/spree/dispatcher.rb
@@ -5,15 +5,7 @@ module Spree
       actions = Spree::PermittedMessages::MESSAGES.fetch(name) { Rails.logger.error("Dispatcher: Message #{name} not found, nothing more to do."); return }
       actions.each do |action|
         begin
-          method_name = action[1]
-          action_class = Object.const_get(action[0])
-          instance = action_class.respond_to?(method_name) ? action_class : action_class.new
-          next unless instance.respond_to?(method_name)
-          if instance.method(method_name).arity == 0
-            instance.public_send(method_name)
-          else
-            instance.public_send(method_name, *args)
-          end
+          action.call(args)
         rescue => exception
           Rails.logger.error("Error sending message to #{action[0]} and method #{action[1]}\n#{exception}")
         end

--- a/core/app/notifications/spree/dispatcher.rb
+++ b/core/app/notifications/spree/dispatcher.rb
@@ -1,10 +1,8 @@
 
 module Spree
   module Dispatcher
-    MESSAGES = Spree::PermittedMessages::MESSAGES
-
     def self.send_message(name, *args)
-      actions = MESSAGES.fetch(name) { Rails.logger.error("Dispatcher: Message #{name} not found, nothing more to do."); return }
+      actions = Spree::PermittedMessages::MESSAGES.fetch(name) { Rails.logger.error("Dispatcher: Message #{name} not found, nothing more to do."); return }
       actions.each do |action|
         begin
           method_name = action[1]
@@ -17,7 +15,7 @@ module Spree
             instance.public_send(method_name, *args)
           end
         rescue => exception
-          logger.error("Error sending message to #{action[0]} and method #{action[1]}")
+          Rails.logger.error("Error sending message to #{action[0]} and method #{action[1]}\n#{exception}")
         end
       end
     end

--- a/core/app/notifications/spree/dispatcher.rb
+++ b/core/app/notifications/spree/dispatcher.rb
@@ -1,0 +1,25 @@
+
+module Spree
+  module Dispatcher
+    MESSAGES = Spree::PermittedMessages::MESSAGES
+
+    def self.send_message(name, *args)
+      actions = MESSAGES.fetch(name) { Rails.logger.error("Dispatcher: Message #{name} not found, nothing more to do."); return }
+      actions.each do |action|
+        begin
+          method_name = action[1]
+          action_class = Object.const_get(action[0])
+          instance = action_class.respond_to?(method_name) ? action_class : action_class.new
+          next unless instance.respond_to?(method_name)
+          if instance.method(method_name).arity == 0
+            instance.public_send(method_name)
+          else
+            instance.public_send(method_name, *args)
+          end
+        rescue => exception
+          logger.error("Error sending message to #{action[0]} and method #{action[1]}")
+        end
+      end
+    end
+  end
+end

--- a/core/lib/spree/core.rb
+++ b/core/lib/spree/core.rb
@@ -66,6 +66,7 @@ require 'spree/i18n'
 require 'spree/localized_number'
 require 'spree/money'
 require 'spree/permitted_attributes'
+require 'spree/permitted_messages'
 
 require 'spree/core/importer'
 require 'spree/core/permalinks'

--- a/core/lib/spree/permitted_messages.rb
+++ b/core/lib/spree/permitted_messages.rb
@@ -1,0 +1,12 @@
+module Spree
+  # Spree::PermittedAttributes contains the attributes permitted through strong
+  # params in various controllers in the frontend. Extensions and stores that
+  # need additional params to be accepted can mutate these arrays to add them.
+  module PermittedMessages
+    MESSAGES = {
+      order_canceled: [['Spree:OrderMailer','cancel_email']]
+    }
+
+    mattr_reader(MESSAGES)
+  end
+end

--- a/core/lib/spree/permitted_messages.rb
+++ b/core/lib/spree/permitted_messages.rb
@@ -4,7 +4,11 @@ module Spree
   # need additional params to be accepted can mutate these arrays to add them.
   module PermittedMessages
     MESSAGES = {
-      order_canceled: [['Spree:OrderMailer','cancel_email']]
+      carton_shipped: [->(*args) { Spree::Config.carton_shipped_email_class.shipped_email(args) } ],
+      order_canceled: [->(*args) { Spree::OrderMailer.cancel_email(args) }],
+      order_confirmed: [->(*args) { Spree::OrderMailer.confirm_email(args) }],
+      order_inventory_canceled: [->(*args) { Spree::OrderMailer.inventory_cancellation_email(args) }],
+      reimbursement_processed: [->(*args) { Spree::ReimbursementMailer.reimbursement_email(args) }]
     }
 
     mattr_reader(MESSAGES)

--- a/core/lib/spree/permitted_messages.rb
+++ b/core/lib/spree/permitted_messages.rb
@@ -1,7 +1,7 @@
 module Spree
-  # Spree::PermittedAttributes contains the attributes permitted through strong
-  # params in various controllers in the frontend. Extensions and stores that
-  # need additional params to be accepted can mutate these arrays to add them.
+  # Spree::PermittedMessages contains the messages permitted to be sent to the
+  # `Spree::Dispatcher`. Extensions and stores that need additional events to be
+  # accepted can mutate these arrays to add them.
   module PermittedMessages
     MESSAGES = {
       carton_shipped: [->(*args) { Spree::Config.carton_shipped_email_class.shipped_email(args) } ],

--- a/core/lib/spree/permitted_messages.rb
+++ b/core/lib/spree/permitted_messages.rb
@@ -4,11 +4,11 @@ module Spree
   # accepted can mutate these arrays to add them.
   module PermittedMessages
     MESSAGES = {
-      carton_shipped: [->(*args) { Spree::Config.carton_shipped_email_class.shipped_email(args) } ],
-      order_canceled: [->(*args) { Spree::OrderMailer.cancel_email(args) }],
-      order_confirmed: [->(*args) { Spree::OrderMailer.confirm_email(args) }],
-      order_inventory_canceled: [->(*args) { Spree::OrderMailer.inventory_cancellation_email(args) }],
-      reimbursement_processed: [->(*args) { Spree::ReimbursementMailer.reimbursement_email(args) }]
+      carton_shipped: [->(args) { Spree::Config.carton_shipped_email_class.shipped_email(*args).deliver_later } ],
+      order_canceled: [->(args) { Spree::OrderMailer.cancel_email(*args).deliver_later }],
+      order_confirmed: [->(args) { Spree::OrderMailer.confirm_email(*args).deliver_later }],
+      order_inventory_canceled: [->(args) { Spree::OrderMailer.inventory_cancellation_email(*args).deliver_later }],
+      reimbursement_processed: [->(args) { Spree::ReimbursementMailer.reimbursement_email(*args).deliver_later }]
     }
 
     mattr_reader(MESSAGES)

--- a/core/spec/notifications/dispatcher_spec.rb
+++ b/core/spec/notifications/dispatcher_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 module TestMailer
   class << self
-    attr_accessor :no_args_received
+    attr_accessor :no_args_called
     attr_accessor :args
 
     def no_args
-      @no_args_received = true
+      @no_args_called = true
     end
 
     def with_args(args)
@@ -16,25 +16,61 @@ module TestMailer
 end
 
 RSpec.describe Spree::Dispatcher do
-  it 'does not die when receiving a bogus message name' do
-    expect{Spree::Dispatcher.send_message(:completely_fake_message_name)}.not_to raise_error
-  end
-
-  context 'sends message' do
-    before do
-      Spree::PermittedMessages::MESSAGES[:test_no_args] = [['TestMailer', 'no_args']]
-      Spree::PermittedMessages::MESSAGES[:test_args] = [['TestMailer', 'with_args']]
-      TestMailer.no_args_received = false
+  describe '#send_message' do
+    context 'message is sent with no configuration existing' do
+      it 'does not fail hard' do
+        expect{Spree::Dispatcher.send_message(:completely_fake_message_name)}.not_to raise_error
+      end
     end
 
-    it 'sends to configured receivers' do
-      expect{Spree::Dispatcher.send_message(:test_no_args)}.not_to raise_error
-      expect(TestMailer.no_args_received).to eq true
+    context 'message with no extra arguments' do
+      before do
+        Spree::PermittedMessages::MESSAGES[:test_no_args] = [['TestMailer', 'no_args']]
+        TestMailer.no_args_called = false
+      end
+
+      it 'sends to configured receivers' do
+        expect{Spree::Dispatcher.send_message(:test_no_args)}.not_to raise_error
+        expect(TestMailer.no_args_called).to eq true
+      end
     end
 
-    it 'sends along arguments to receivers' do
-      expect{Spree::Dispatcher.send_message(:test_args, 2)}.not_to raise_error
-      expect(TestMailer.args).to eq 2
+    context 'message with arguments' do
+      before do
+        Spree::PermittedMessages::MESSAGES[:test_args] = [['TestMailer', 'with_args']]
+        TestMailer.args = nil
+      end
+
+      it 'sends along arguments to receivers' do
+        expect{Spree::Dispatcher.send_message(:test_args, 2)}.not_to raise_error
+        expect(TestMailer.args).to eq 2
+      end
+
+      context 'receiver does not accept arguments' do
+        before do
+          Spree::PermittedMessages::MESSAGES[:test_args] = [['TestMailer', 'no_args']]
+          TestMailer.no_args_called = false
+        end
+
+        it 'still calls receiver' do
+          expect{Spree::Dispatcher.send_message(:test_args, 2)}.not_to raise_error
+          expect(TestMailer.no_args_called).to eq true
+        end
+      end
+
+      context 'multiple receivers' do
+        before do
+          Spree::PermittedMessages::MESSAGES[:test_args] = [['TestMailer', 'with_args'],['TestMailer','no_args']]
+          TestMailer.args = nil
+          TestMailer.no_args_called = false;
+        end
+
+        it 'calls both receivers' do
+          expect{Spree::Dispatcher.send_message(:test_args, 2)}.not_to raise_error
+          expect(TestMailer.args).to eq 2
+          expect(TestMailer.no_args_called).to eq true
+        end
+      end
     end
   end
 end

--- a/core/spec/notifications/dispatcher_spec.rb
+++ b/core/spec/notifications/dispatcher_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Spree::Dispatcher do
 
     context 'message with no extra arguments' do
       before do
-        Spree::PermittedMessages::MESSAGES[:test_no_args] = [['TestMailer', 'no_args']]
+        Spree::PermittedMessages::MESSAGES[:test_no_args] = [->(args) { TestMailer.no_args }]
         TestMailer.no_args_called = false
       end
 
@@ -37,7 +37,7 @@ RSpec.describe Spree::Dispatcher do
 
     context 'message with arguments' do
       before do
-        Spree::PermittedMessages::MESSAGES[:test_args] = [['TestMailer', 'with_args']]
+        Spree::PermittedMessages::MESSAGES[:test_args] = [->(args) { TestMailer.with_args(*args) }]
         TestMailer.args = nil
       end
 
@@ -48,7 +48,7 @@ RSpec.describe Spree::Dispatcher do
 
       context 'receiver does not accept arguments' do
         before do
-          Spree::PermittedMessages::MESSAGES[:test_args] = [['TestMailer', 'no_args']]
+          Spree::PermittedMessages::MESSAGES[:test_args] = [->(args) { TestMailer.no_args }]
           TestMailer.no_args_called = false
         end
 
@@ -60,7 +60,7 @@ RSpec.describe Spree::Dispatcher do
 
       context 'multiple receivers' do
         before do
-          Spree::PermittedMessages::MESSAGES[:test_args] = [['TestMailer', 'with_args'],['TestMailer','no_args']]
+          Spree::PermittedMessages::MESSAGES[:test_args] = [->(args) { TestMailer.with_args(*args) }, ->(args) { TestMailer.no_args }]
           TestMailer.args = nil
           TestMailer.no_args_called = false;
         end

--- a/core/spec/notifications/dispatcher_spec.rb
+++ b/core/spec/notifications/dispatcher_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+module TestMailer
+  class << self
+    attr_accessor :no_args_received
+    attr_accessor :args
+
+    def no_args
+      @no_args_received = true
+    end
+
+    def with_args(args)
+      @args = args
+    end
+  end
+end
+
+RSpec.describe Spree::Dispatcher do
+  it 'does not die when receiving a bogus message name' do
+    expect{Spree::Dispatcher.send_message(:completely_fake_message_name)}.not_to raise_error
+  end
+
+  context 'sends message' do
+    before do
+      Spree::PermittedMessages::MESSAGES[:test_no_args] = [['TestMailer', 'no_args']]
+      Spree::PermittedMessages::MESSAGES[:test_args] = [['TestMailer', 'with_args']]
+      TestMailer.no_args_received = false
+    end
+
+    it 'sends to configured receivers' do
+      expect{Spree::Dispatcher.send_message(:test_no_args)}.not_to raise_error
+      expect(TestMailer.no_args_received).to eq true
+    end
+
+    it 'sends along arguments to receivers' do
+      expect{Spree::Dispatcher.send_message(:test_args, 2)}.not_to raise_error
+      expect(TestMailer.args).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
This PR would add the Dispatch. Dispatch is a set of functionality for effectively passing named messages around the application. Messages are defined in config, and allow for any number of Procs to be defined for them.

This allows a caller who wants something to happen (e.g. an email sent out) to call send_message on the Dispatch and then the Dispatch will forward that message along to all receivers. It could be none, one or many.